### PR TITLE
Publish also on OpenVSX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: '16'
         cache: 'npm'
     - name: Install global dependencies
-      run: npm install -g typescript vsce
+      run: npm install -g typescript vsce ovsx
     - name: npm-ci
       run: npm ci
     - name: npm-compile
@@ -34,9 +34,16 @@ jobs:
       with:
         name: binary
         path: snippets-for-asciidoc-*.vsix
-    - name: Publish
-      shell: bash
+    - name: Publish to Open VSX Registry
+      uses: HaaLeo/publish-vscode-extension@v1
       if: ${{ github.ref_type == 'tag' }}
-      env:
-        VSCODE_TOKEN: ${{ secrets.VSCODE_TOKEN }}
-      run: vsce publish -p "$VSCODE_TOKEN"
+      id: publishToOpenVSX
+      with:
+        pat: ${{ secrets.OPEN_VSX_TOKEN }}
+    - name: Publish to Visual Studio Marketplace
+      uses: HaaLeo/publish-vscode-extension@v1
+      if: ${{ github.ref_type == 'tag' }}
+      with:
+        pat: ${{ secrets.VSCODE_TOKEN }}
+        registryUrl: https://marketplace.visualstudio.com
+        extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}


### PR DESCRIPTION
using recommended GitHub Actions on official open VSX documentation
https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#github-action

The token to publish is called OPEN_VSX_TOKEN. @abhatt-rh You will need to create it and configure in environment by following steps 1, 2, 3 and 4 from https://github.com/apupier/asciidoc_vscode_snippets/pull/new/5-ProvidePublishToOpenVSX

fixes #5
