### PR TITLE
Add VS Code AsciiDoc as Extension Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "snippets-for-asciidoc" extension will be documented 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+
+## 0.0.2
+
+- Add explicti dependency to VS Code AsciiDoc extension
+
+## 0.0.1
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "AsciiDoc",
     "Red Hat"
   ],
+  "extensionDependencies": [
+	"asciidoctor.asciidoctor-vscode"
+  ],
   "activationEvents": [
     "onLanguage:asciidoc"
   ],


### PR DESCRIPTION
it allows to have VS Code AsciiDoc extension automatically installed when installing this extension (using install from vsix.. in this animated images because the extension with the modification si obvioulst,no tyet on the Marketplace but it will work the sam ewith a classical install from the Marketplace)
![Peek 2022-08-01 21-15](https://user-images.githubusercontent.com/1105127/182228270-d7772668-e504-4df4-84e1-fa0e0cf11cf2.gif)
